### PR TITLE
APPENG-561: Fixed the ansible error when AMQ script exits due to non-existent archive

### DIFF
--- a/automation/ansible/roles/setup_broker/templates/install_amq.sh.j2
+++ b/automation/ansible/roles/setup_broker/templates/install_amq.sh.j2
@@ -54,9 +54,10 @@ if [ -f $AMQ_BINARY_FULL_PATH ]; then
       --data {{ amq_advanced_topology_dir }}/{{ broker_data_directory }} \
       {{ broker_name }}
 else
-    echo "..."
-    echo "AMQ zip is not in it's location ($AMQ_BINARY_FULL_PATH)"
-    echo "Please fix the above error and re-run"
-    echo "..."
+    echo "******************************************************************"
+    echo "** -->> AMQ zip is not in it's location ($AMQ_BINARY_FULL_PATH) <<--"
+    echo "** -->> Please fix the above error and re-run"
+    echo "******************************************************************"
+    exit 10
 fi
 


### PR DESCRIPTION
Returning a different exit code to indicate error. Earlier there was no exit, which made it a success