### PR TITLE
APPENG-761: Config for mirroring within same cluster (in same region)

### DIFF
--- a/automation/ansible/hosts-r1_vpc1_mirroring.yml
+++ b/automation/ansible/hosts-r1_vpc1_mirroring.yml
@@ -8,71 +8,35 @@ r1_vpc1_brokers:
       broker_name: broker-01
       broker_private_ip: "{{ r1_vpc1_private_ip_prefix }}.0.51"
       is_live_broker: true
-      mirror_primary_host_idx: 0
-      mirror_backup_host_idx: 1
+      mirror_primary_host_idx: 2
+      mirror_backup_host_idx: 3
       ansible_host: "{{ r1_broker01_live_ip }}"
     r1-broker02-bak:
       broker_data_directory: one
       broker_name: broker-02
       broker_private_ip: "{{ r1_vpc1_private_ip_prefix }}.64.51"
-      mirror_primary_host_idx: 1
-      mirror_backup_host_idx: 0
+      mirror_primary_host_idx: 3
+      mirror_backup_host_idx: 2
       ansible_host: "{{ r1_broker02_bak_ip }}"
     r1-broker03-live:
       broker_data_directory: two
       broker_name: broker-03
       broker_private_ip: "{{ r1_vpc1_private_ip_prefix }}.128.51"
       is_live_broker: true
-      mirror_primary_host_idx: 2
-      mirror_backup_host_idx: 3
+      mirror_primary_host_idx: 0
+      mirror_backup_host_idx: 1
       ansible_host: "{{ r1_broker03_live_ip }}"
     r1-broker04-bak:
       broker_data_directory: two
       broker_name: broker-04
       broker_private_ip: "{{ r1_vpc1_private_ip_prefix }}.0.52"
-      mirror_primary_host_idx: 3
-      mirror_backup_host_idx: 2
+      mirror_primary_host_idx: 1
+      mirror_backup_host_idx: 0
       ansible_host: "{{ r1_broker04_bak_ip }}"
   vars:
     nfs_server_ip: "{{ r1_vpc1_private_ip_prefix }}.0.50"
-    mirror_group: r2_vpc1_brokers
-
-# Brokers in region 2 - vpc1
-r2_vpc1_brokers:
-  hosts:
-    r2-broker01-live:
-      broker_data_directory: one
-      broker_name: broker-01
-      broker_private_ip: "{{ r2_vpc1_private_ip_prefix }}.0.51"
-      is_live_broker: true
-      mirror_primary_host_idx: 0
-      mirror_backup_host_idx: 1
-      ansible_host: "{{ r2_broker01_live_ip }}"
-    r2-broker02-bak:
-      broker_data_directory: one
-      broker_name: broker-02
-      broker_private_ip: "{{ r2_vpc1_private_ip_prefix }}.64.51"
-      mirror_primary_host_idx: 1
-      mirror_backup_host_idx: 0
-      ansible_host: "{{ r2_broker02_bak_ip }}"
-    r2-broker03-live:
-      broker_data_directory: two
-      broker_name: broker-03
-      broker_private_ip: "{{ r2_vpc1_private_ip_prefix }}.128.51"
-      is_live_broker: true
-      mirror_primary_host_idx: 2
-      mirror_backup_host_idx: 3
-      ansible_host: "{{ r2_broker03_live_ip }}"
-    r2-broker04-bak:
-      broker_data_directory: two
-      broker_name: broker-04
-      broker_private_ip: "{{ r2_vpc1_private_ip_prefix }}.0.52"
-      mirror_primary_host_idx: 3
-      mirror_backup_host_idx: 2
-      ansible_host: "{{ r2_broker04_bak_ip }}"
-  vars:
-    nfs_server_ip: "{{ r2_vpc1_private_ip_prefix }}.0.50"
     mirror_group: r1_vpc1_brokers
+
 
 r1_nfs_servers:
   hosts:
@@ -151,10 +115,13 @@ all:
     # whether to delete AMQ binary when resetting the NFS server
     delete_amq_archive: false
 
+    # Jmeter client setup playbook variables.
+    jmeter_hub_router_ip: "{{ r1_vpc1_private_ip_prefix }}.128.100"
+    jmeter_hub_router_port: 5672
+    jmeter_binary_download_uri: https://dlcdn.apache.org/jmeter/binaries
+    jmeter_binary_version: apache-jmeter-5.4.3
+    jmeter_binary_archive: "{{ jmeter_binary_version }}.zip"
+    jmeter_remote_bin_dir: jmeter
+
     # Private IP prefixes for each region/vpc
-    r1_vpc1_private_ip_prefix: "10.101"
-    r1_vpc2_private_ip_prefix: "10.102"
-    r2_vpc1_private_ip_prefix: "10.201"
-    r2_vpc2_private_ip_prefix: "10.202"
-
-
+    r1_vpc1_private_ip_prefix: "10.70"

--- a/automation/ansible/hosts.yml
+++ b/automation/ansible/hosts.yml
@@ -252,8 +252,6 @@ nfs_servers:
   vars:
     user_nobody: "nobody"
     nfs_service: "nfs-server.service"
-    # todo(sg): whether to delete AMQ binary when resetting the NFS server
-    delete_amq_archive: false
     packages:
       - nfs-utils
 
@@ -283,6 +281,10 @@ all:
     enable_amq_mirroring: true
     amq_binary_version: amq-broker-7.9.0
     amq_binary_archive: "{{ amq_binary_version }}-bin.zip"
+
+    # whether to delete AMQ binary when resetting the NFS server
+    delete_amq_archive: false
+
     # Jmeter client setup playbook variables.
     jmeter_hub_router_ip: "{{ r1_vpc1_private_ip_prefix }}.128.100"
     jmeter_hub_router_port: 5672

--- a/automation/ansible/roles/reset_nfs/tasks/main.yml
+++ b/automation/ansible/roles/reset_nfs/tasks/main.yml
@@ -17,14 +17,14 @@
     update_cache: yes
 
 - name: Remove NFS mount directory (for brokers) recursively
-  when: delete_amq_archive is false
+  when: delete_amq_archive is not defined or delete_amq_archive is false
   ansible.builtin.file:
     path: "{{ amq_advanced_topology_dir }}"
     state: absent
   register: remove_nfs_mount_broker_dir
 
 - name: Remove NFS mount "root" directory recursively
-  when: delete_amq_archive is true
+  when: delete_amq_archive is defined and delete_amq_archive is true
   ansible.builtin.file:
     path: "{{ nfs_files_mount }}"
     state: absent

--- a/automation/ansible/roles/setup_broker/templates/broker.xml.j2
+++ b/automation/ansible/roles/setup_broker/templates/broker.xml.j2
@@ -154,20 +154,39 @@ under the License.
     {% if enable_amq_mirroring is defined and enable_amq_mirroring == true %}
         {% if enable_ssl is defined and enable_ssl == true %}
             <!-- For setting up mirroring between brokers -->
-            <broker-connections>
-                <!-- Mirror to Dallas Live server and backup server -->
-                <amqp-connection uri="tcp://{{ amq_mirror_primary_broker_ip }}:5672?sslEnabled=true;trustStorePath=../etc/{{ CA_CERT_FILE_PREFIX }}-truststore.p12;trustStorePassword={{ STORE_PASS }};verifyHost=false;enabledProtocols=TLSv1.2,TLSv1.3;#tcp://{{ amq_mirror_backup_broker_ip }}:5672?sslEnabled=true;trustStorePath=../etc/{{ CA_CERT_FILE_PREFIX }}-truststore.p12;trustStorePassword={{ STORE_PASS }};verifyHost=false;enabledProtocols=TLSv1.2,TLSv1.3;" name="{{ inventory_hostname }}-mirror">
-                    <mirror/>
-                </amqp-connection>
-            </broker-connections>
+            {% if is_live_broker is defined and is_live_broker == true %}
+                <!-- live is main and backup is the backup -->
+                <broker-connections>
+                    <amqp-connection uri="tcp://{{ amq_mirror_primary_broker_ip }}:5672{{ amq_conn_ssl_params }}#tcp://{{ amq_mirror_backup_broker_ip }}:5672{{ amq_conn_ssl_params }}" name="{{ amq_mirror_primary_broker_name }}">
+                        <mirror/>
+                    </amqp-connection>
+                </broker-connections>
+            {% else %}
+                <!-- backup is main and live is the backup -->
+                <broker-connections>
+                    <amqp-connection uri="tcp://{{ amq_mirror_backup_broker_ip }}:5672{{ amq_conn_ssl_params }}#tcp://{{ amq_mirror_primary_broker_ip }}:5672{{ amq_conn_ssl_params }}" name="{{ amq_mirror_backup_broker_name }}">
+                        <mirror/>
+                    </amqp-connection>
+                </broker-connections>
+            {% endif %}
         {% else %}
             <!-- For setting up mirroring between brokers -->
-            <broker-connections>
-                <!-- Mirror to Dallas Live server and backup server -->
-                <amqp-connection uri="tcp://{{ amq_mirror_primary_broker_ip }}:5672#tcp://{{ amq_mirror_backup_broker_ip }}:5672" name="{{ inventory_hostname }}-mirror">
-                    <mirror/>
-                </amqp-connection>
-            </broker-connections>
+
+            {% if is_live_broker is defined and is_live_broker == true %}
+                <!-- live is main and backup is the backup -->
+                <broker-connections>
+                    <amqp-connection uri="tcp://{{ amq_mirror_primary_broker_ip }}:5672" name="{{ amq_mirror_primary_broker_name }}">
+                        <mirror/>
+                    </amqp-connection>
+                </broker-connections>
+            {% else %}
+                <!-- backup is main and live is the backup -->
+                <broker-connections>
+                    <amqp-connection uri="tcp://{{ amq_mirror_backup_broker_ip }}:5672" name="{{ amq_mirror_backup_broker_name }}">
+                        <mirror/>
+                    </amqp-connection>
+                </broker-connections>
+            {% endif %}
 
             <security-enabled>false</security-enabled>
         {% endif %}

--- a/automation/ansible/roles/setup_broker/vars/main.yml
+++ b/automation/ansible/roles/setup_broker/vars/main.yml
@@ -8,7 +8,12 @@ amq_broker_install_dir: "{{ amq_broker_dir }}/{{ broker_name }}"
 amq_config_dir: "{{ amq_broker_install_dir }}/etc"
 amq_jgroups_config: "{{ amq_config_dir }}/jgroups-ping.xml"
 
+#amq_conn_ssl_params: "?sslEnabled=true;trustStorePath=../etc/{{ CA_CERT_FILE_PREFIX }}-truststore.p12;trustStorePassword={{ STORE_PASS }};verifyHost=false;enabledProtocols=TLSv1.2,TLSv1.3;"
+amq_conn_ssl_params: "?sslEnabled=true;trustStorePath=../etc/{{ CA_CERT_FILE_PREFIX | default(omit) }}-truststore.p12;trustStorePassword={{ STORE_PASS | default(omit) }};verifyHost=false;enabledProtocols=TLSv1.2,TLSv1.3;"
+
 # Primary mirror broker private IP
 amq_mirror_primary_broker_ip: "{{ hostvars[groups[mirror_group][mirror_primary_host_idx]]['broker_private_ip'] }}"
+amq_mirror_primary_broker_name: "{{ hostvars[groups[mirror_group][mirror_primary_host_idx]]['broker_name'] }}"
 # Backup mirror broker private IP
 amq_mirror_backup_broker_ip: "{{ hostvars[groups[mirror_group][mirror_backup_host_idx]]['broker_private_ip'] }}"
+amq_mirror_backup_broker_name: "{{ hostvars[groups[mirror_group][mirror_backup_host_idx]]['broker_name'] }}"


### PR DESCRIPTION
Config for mirroring within same cluster (in same region). Adding broker-connections conditionally for live/backup (as well as ssl/non-ssl).

Also fixed the issue where the reset wasn't removing broker configs - a property was missing